### PR TITLE
Print ingest errors to standard error output, since logging them is not an option

### DIFF
--- a/logscale-log/src/logscale_structured_logger.rs
+++ b/logscale-log/src/logscale_structured_logger.rs
@@ -36,12 +36,14 @@ impl StructuredLogIngester {
                 let client = self.client.clone();
 
                 tokio::spawn(async move {
-                    let _ = client
+                    if client
                         .ingest_structured(&[StructuredLogsIngestRequest {
                             tags: HashMap::new(),
                             events: &[log_event],
                         }])
-                        .await;
+                        .await.is_err() {
+                            eprintln!("An error occurred while trying to ingest logs to Falcon LogScale.");
+                        }
                 });
             }
             LoggerIngestPolicy::Periodically(_) => {
@@ -84,6 +86,8 @@ impl StructuredLogIngester {
                     if let Ok(mut pending_events) = pending_events.lock() {
                         pending_events.clear();
                     }
+                } else {
+                    eprintln!("An error occurred while trying to ingest logs to Falcon LogScale.");
                 }
             }
         });

--- a/logscale-log/src/logscale_unstructured_logger.rs
+++ b/logscale-log/src/logscale_unstructured_logger.rs
@@ -41,7 +41,9 @@ impl UnstructuredLogIngester {
                     let request_content = [log_event];
                     let request = UnstructuredLogsIngestRequest::from_log_events(&request_content);
 
-                    let _ = client.ingest_unstructured(&[request]).await;
+                    if client.ingest_unstructured(&[request]).await.is_err() {
+                        eprintln!("An error occurred while trying to ingest logs to Falcon LogScale.");
+                    }
                 });
             }
             LoggerIngestPolicy::Periodically(_) => {
@@ -81,6 +83,8 @@ impl UnstructuredLogIngester {
                     if let Ok(mut pending_events) = pending_events.lock() {
                         pending_events.clear();
                     }
+                } else {
+                    eprintln!("An error occurred while trying to ingest logs to Falcon LogScale.");
                 }
             }
         });


### PR DESCRIPTION
Writes ingest errors to standard error output. Since the thing that is failing is the log ingestion, trying to log it doesn't make much sense, so this is the best we can do I think.